### PR TITLE
only populate the fields for the payload if parameter value was passe…

### DIFF
--- a/lib/refocus/samples.rb
+++ b/lib/refocus/samples.rb
@@ -16,8 +16,9 @@ module Refocus
       Collector.new(http: http)
     end
 
-    def upsert(name:, aspect:, value:nil, messageBody:nil, messageCode:nil, relatedLinks:nil)
-      sample = format_sample(name:name, aspect: aspect, value: value, messageBody: messageBody, messageCode: messageCode, relatedLinks: relatedLinks)
+    def upsert(name:, aspect:, value:nil, message_body:nil, message_code:nil, related_links:nil)
+      sample = format_sample(name:name, aspect: aspect, value: value, message_body: message_body,
+                             message_code: message_code, related_links: related_links)
       json(http.post("upsert", body: sample, expects: 200))
     end
     alias_method :submit, :upsert

--- a/lib/refocus/samples.rb
+++ b/lib/refocus/samples.rb
@@ -16,7 +16,7 @@ module Refocus
       Collector.new(http: http)
     end
 
-    def upsert(name:, aspect:, value:"", messageBody:"", messageCode:"", relatedLinks:[])
+    def upsert(name:, aspect:, value:nil, messageBody:nil, messageCode:nil, relatedLinks:nil)
       sample = format_sample(name:name, aspect: aspect, value: value, messageBody: messageBody, messageCode: messageCode, relatedLinks: relatedLinks)
       json(http.post("upsert", body: sample, expects: 200))
     end
@@ -35,11 +35,6 @@ module Refocus
 
     def get(subject:, aspect:)
       json(http.get(URI.escape("#{subject}\|#{aspect}")))
-    end
-
-    private
-    def format_sample(name:, aspect:, value:"", messageBody:"", messageCode:"", relatedLinks:[])
-      {name: "#{name}|#{aspect}", value: value.to_s, messageBody: messageBody, messageCode: messageCode, relatedLinks: relatedLinks}
     end
 
   end

--- a/lib/refocus/samples/collector.rb
+++ b/lib/refocus/samples/collector.rb
@@ -27,8 +27,8 @@ module Refocus
       def format_sample(name:, aspect:, value:nil, message_body:nil, message_code:nil, related_links:nil)
         sample = {name: "#{name}|#{aspect}"}
         sample[:value] = value.to_s if value
-        sample[:messageBody] = message_body if message_body
-        sample[:messageCode] = message_code if message_code
+        sample[:messageBody] = message_body.to_s if message_body
+        sample[:messageCode] = message_code.to_s if message_code
         sample[:relatedLinks] = related_links if related_links
         sample
       end

--- a/lib/refocus/samples/collector.rb
+++ b/lib/refocus/samples/collector.rb
@@ -12,8 +12,9 @@ module Refocus
         @samples = []
       end
 
-      def add(name:, aspect:, value:"", messageBody:"", messageCode:"", relatedLinks:[])
-        samples << {name: "#{name}|#{aspect}", value: value.to_s, messageBody: messageBody, messageCode: messageCode, relatedLinks: relatedLinks}
+      def add(name:, aspect:, value:nil, messageBody:nil, messageCode:nil, relatedLinks:nil)
+        samples << format_sample(name:name, aspect: aspect, value: value, messageBody: messageBody,
+                                 messageCode: messageCode, relatedLinks: relatedLinks)
       end
 
       def upsert_bulk
@@ -22,6 +23,15 @@ module Refocus
         result
       end
       alias_method :submit, :upsert_bulk
+
+      def format_sample(name:, aspect:, value:nil, messageBody:nil, messageCode:nil, relatedLinks:nil)
+        sample = {name: "#{name}|#{aspect}"}
+        sample[:value] = value.to_s if value
+        sample[:messageBody] = messageBody.to_s if messageBody
+        sample[:messageCode] = messageCode.to_s if messageCode
+        sample[:relatedLinks] = relatedLinks if relatedLinks
+        sample
+      end
 
     end
   end

--- a/lib/refocus/samples/collector.rb
+++ b/lib/refocus/samples/collector.rb
@@ -12,9 +12,9 @@ module Refocus
         @samples = []
       end
 
-      def add(name:, aspect:, value:nil, messageBody:nil, messageCode:nil, relatedLinks:nil)
-        samples << format_sample(name:name, aspect: aspect, value: value, messageBody: messageBody,
-                                 messageCode: messageCode, relatedLinks: relatedLinks)
+      def add(name:, aspect:, value:nil, message_body:nil, message_code:nil, related_links:nil)
+        samples << format_sample(name:name, aspect: aspect, value: value, message_body: message_body,
+                                 message_code: message_code, related_links: related_links)
       end
 
       def upsert_bulk
@@ -24,12 +24,12 @@ module Refocus
       end
       alias_method :submit, :upsert_bulk
 
-      def format_sample(name:, aspect:, value:nil, messageBody:nil, messageCode:nil, relatedLinks:nil)
+      def format_sample(name:, aspect:, value:nil, message_body:nil, message_code:nil, related_links:nil)
         sample = {name: "#{name}|#{aspect}"}
         sample[:value] = value.to_s if value
-        sample[:messageBody] = messageBody.to_s if messageBody
-        sample[:messageCode] = messageCode.to_s if messageCode
-        sample[:relatedLinks] = relatedLinks if relatedLinks
+        sample[:messageBody] = message_body if message_body
+        sample[:messageCode] = message_code if message_code
+        sample[:relatedLinks] = related_links if related_links
         sample
       end
 


### PR DESCRIPTION
Hi @sheax0r 

I was thinking about this a bit on my way home from work today, and realized that I should only populate the optional fields in the API payload if they were passed in as arguments. The previous behavior of defaulting the optional values to "" would actually override the existing values of the object if they weren't populated by the user.

Sorry for the sloppiness!